### PR TITLE
Fixes nuxt-hub/cli#8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 .env
+.idea/

--- a/src/commands/deploy.mjs
+++ b/src/commands/deploy.mjs
@@ -34,6 +34,11 @@ export default defineCommand({
       type: 'boolean',
       description: 'Force the current deployment as preview.',
       default: false
+    },
+    dotenv: {
+      type: 'string',
+      description: 'Point to another .env file to load, relative to the root directory.',
+      default: ''
     }
   },
   async setup({ args }) {
@@ -83,7 +88,11 @@ export default defineCommand({
       if (!deps['@nuxthub/core']) {
         consola.warn('`@nuxthub/core` is not installed, make sure to install it with `npx nuxt module add hub`')
       }
-      await execa('./node_modules/.bin/nuxi', ['build', '--preset=cloudflare-pages'], { stdio: 'inherit' })
+      const nuxiBuildArgs = ['--preset=cloudflare-pages'];
+      if (args.dotenv) {
+        nuxiBuildArgs.push(`--dotenv=${args.dotenv}`);
+      }
+      await execa('./node_modules/.bin/nuxi', ['build', ...nuxiBuildArgs], { stdio: 'inherit' })
         .catch((err) => {
           if (err.code === 'ENOENT') {
             consola.error('`nuxt` is not installed, please make sure that you are inside a Nuxt project.')

--- a/src/commands/init.mjs
+++ b/src/commands/init.mjs
@@ -4,7 +4,7 @@ import { execa } from 'execa'
 export default defineCommand({
   meta: {
     name: 'init',
-    description: 'Initialize a fresh NuxtHUb project, alias of `nuxi init -t hub`.',
+    description: 'Initialize a fresh NuxtHub project, alias of `nuxi init -t hub`.',
   },
   async setup({ args }) {
     await execa('npx', ['nuxi@latest', 'init', '-t', 'hub', ...args._], { stdio: 'inherit' })


### PR DESCRIPTION
Implements the `dotenv` option for `nuxi build`, for example `nuxthub deploy --dotenv=.env.vars`

Note: While supporting all [nuxt build options](https://nuxt.com/docs/api/commands/build) would be nice, it is out of scope of the original github issue (#8)