### PR TITLE
feat: support local `.env` when previewing

### DIFF
--- a/src/commands/deploy.mjs
+++ b/src/commands/deploy.mjs
@@ -131,6 +131,7 @@ export default defineCommand({
       if (fileKey.startsWith('.wrangler:')) return false
       if (fileKey.startsWith('node_modules:')) return false
       if (fileKey === 'wrangler.toml') return false
+      if (fileKey === '.dev.vars') return false
       if (fileKey.startsWith('database:migrations:')) return false
       return true
     })

--- a/src/commands/preview.mjs
+++ b/src/commands/preview.mjs
@@ -30,7 +30,7 @@ export default defineCommand({
     }
 
     const fileSideEffects = []
-    // Wrangler does not support .env, only a .dev.var
+    // Wrangler does not support .env, only a .dev.vars
     // see https://developers.cloudflare.com/pages/functions/bindings/#interact-with-your-secrets-locally
     const envPath = join(process.cwd(), '.env')
     const devVarsPath = join(distDir, '.dev.vars')

--- a/src/commands/preview.mjs
+++ b/src/commands/preview.mjs
@@ -34,16 +34,16 @@ export default defineCommand({
     // see https://developers.cloudflare.com/pages/functions/bindings/#interact-with-your-secrets-locally
     const envPath = join(process.cwd(), '.env')
     const devVarsPath = join(distDir, '.dev.vars')
-    if (existsSync(envPath) && !existsSync(devVarsPath)) {
-      consola.info(`Copying .env to ${relative(process.cwd(), devVarsPath)}...`)
+    if (existsSync(envPath)) {
+      consola.info(`Copying \`.env\` to \`${relative(process.cwd(), devVarsPath)}\`...`)
       const envVars = await readFile(envPath, 'utf-8').catch(() => '')
       await writeFile(devVarsPath, envVars, 'utf-8')
       fileSideEffects.push(devVarsPath)
     }
 
-    consola.info('Generating wrangler.toml...')
     const wrangler = generateWrangler(hubConfig)
     const wranglerPath = join(distDir, 'wrangler.toml')
+    consola.info(`Generating \`${relative(process.cwd(), wranglerPath)}\`...`)
     fileSideEffects.push(wranglerPath)
     await writeFile(wranglerPath, wrangler)
     const options = { stdin: 'inherit', stdout: 'inherit', cwd: distDir, preferLocal: true, localDir: process.cwd() }


### PR DESCRIPTION
The issue is that when we run `nuxthub preview` our local .env vars aren't used which causes issues for anything requiring them.

There are some interesting discussions here on the matter https://github.com/cloudflare/workers-sdk/issues/3106... 

The workaround we opt for is just copying over the .env to .dev.vars (if it doesn't exist) which should be stable.