### PR TITLE
Add --ip option to allow fix for hanging when run in GitHub Actions.

### DIFF
--- a/src/commands/preview.mjs
+++ b/src/commands/preview.mjs
@@ -19,6 +19,11 @@ export default defineCommand({
       required: false,
       default: '.'
     },
+    ip: {
+      type: 'string',
+      description: 'The IP address to bind the preview server to.',
+      required: false,
+    },
     'log-level': {
       type: 'string',
       description: 'The log level to use.',
@@ -85,6 +90,9 @@ export default defineCommand({
     const wranglerArgs = []
     if (args['log-level']) {
       wranglerArgs.push(`--log-level=${args['log-level']}`)
+    }
+    if (args.ip) {
+      wranglerArgs.push(`--ip=${args.ip}`)
     }
     if (nitroConfig.preset === 'cloudflare-pages') {
       consola.info(`Starting \`wrangler pages dev .\` command...`)


### PR DESCRIPTION
Found this hint in https://github.com/cloudflare/workers-sdk/issues/6280 so am adding an option for this so it can be run with `nuxthub preview --ip=127.0.0.1`.